### PR TITLE
consume-event-from-parent-only

### DIFF
--- a/outputs/index.md
+++ b/outputs/index.md
@@ -45,7 +45,7 @@ export class UserProfile {
 {% endraw %}
 ```
 
-Now when we used this component elsewhere in our app, we can bind the event that `user-profile` emits
+Now when we used this component in its parent component, we can bind the event that `user-profile` emits
 
 ```html
 {% raw %}


### PR DESCRIPTION
Hi there, 
You were saying '...when we used this component elsewhere in our app...' but this event only notifies its parent.
This article explains this in more detail (check "EventEmitters !== DOM events"):
https://netbasal.com/event-emitters-in-angular-13e84ee8d28c
cheers